### PR TITLE
Update overview.mdx

### DIFF
--- a/get-started/overview.mdx
+++ b/get-started/overview.mdx
@@ -13,6 +13,12 @@ Chainlit is an open-source Python package that makes it incredibly fast to build
   />
 </Frame>
 
+4
+
+In the earlier versions of Chainlit, the factory concept was included as part of the API. However, after receiving feedback and evaluating its usefulness, the developers decided to remove it in order to simplify the API and avoid confusion among users.
+
+In the latest version of Chainlit, you will no longer find the following APIs: langchain_factory, langchain_run, langchain_postprocess, llama_index_factory, and langflow_factory.
+
 ## Key features
 
 1. [Build fast:](/examples/openai-sql) Integrate seamlessly with an existing code base or start from scratch in minutes


### PR DESCRIPTION
4

In the earlier versions of Chainlit, the factory concept was included as part of the API. However, after receiving feedback and evaluating its usefulness, the developers decided to remove it in order to simplify the API and avoid confusion among users.

In the latest version of Chainlit, you will no longer find the following APIs: langchain_factory, langchain_run, langchain_postprocess, llama_index_factory, and langflow_factory.