### PR TITLE
Update llm-providers.mdx - update ExampleProvider to Example

### DIFF
--- a/advanced-features/prompt-playground/llm-providers.mdx
+++ b/advanced-features/prompt-playground/llm-providers.mdx
@@ -131,7 +131,7 @@ Example = ExampleProvider(
 Once you have defined the provider, you need to tell Chainlit that it exists.
 
 ```py
-add_llm_provider(ExampleProvider)
+add_llm_provider(Example)
 ```
 
 ## Langchain Provider


### PR DESCRIPTION
When adding a custom LLM Provider, in the add_llm_provider function you pass the object of the custom LLM provider class that you have extended from the Base Provider class not the class itself

Example Provider -> Example