### PR TITLE
adds ploomber cloud to deployment tutorials

### DIFF
--- a/deployment/tutorials.mdx
+++ b/deployment/tutorials.mdx
@@ -16,6 +16,7 @@ After you've successfully set up and tested your Chainlit application locally, t
   `example.com/my-app`.
 </Warning>
 
+- on [Ploomber Cloud](https://docs.cloud.ploomber.io/en/latest/apps/chainlit.html)
 - on [AWS](https://ankushgarg.super.site/how-to-deploy-your-chatgpt-like-app-with-chainlit-and-aws-ecs)
 - on [Azure Container](https://techcommunity.microsoft.com/t5/fasttrack-for-azure/create-an-azure-openai-langchain-chromadb-and-chainlit-chat-app/ba-p/3885602)
 - on [Google Cloud Run](https://pseudohvr.medium.com/deploying-chainlit-on-gcp-72231ba6b77f)


### PR DESCRIPTION
as discussed today, I've added ploomber cloud as a deployment option.

@willydouhard: you mentioned you want to structure this a bit more, I can help with that. Perhaps using [cards](https://docs.chainlit.io/get-started/installation#next-steps) would be better? adding one card per deployment option and include the logo of each platform would be easier to read:

![image](https://github.com/Chainlit/docs/assets/989250/b81e69b3-93e6-4110-8bbe-e00b33a1e318)

another thing you can do is to split "official guides" (either maintained by a company or chainlit's team) vs. "community guides" since the latter have a much higher chance of being unmaintained.


let me know!