### PR TITLE
Fix the issue of 'TypeError: Object of type builtin_function_or_metho…

### DIFF
--- a/integrations/openai.mdx
+++ b/integrations/openai.mdx
@@ -58,7 +58,7 @@ async def on_message(message: cl.Message):
                 "role": "system"
             },
             {
-                "content": input,
+                "content": message.content,
                 "role": "user"
             }
         ],


### PR DESCRIPTION
Fix the issue of 'TypeError: Object of type builtin_function_or_method is not JSON serializable' being thrown at runtime.

If the user runs this sample code directly without examining it carefully, this exception will be thrown.