### PR TITLE
Update link to state_of_the_union in llama-index doc

### DIFF
--- a/integrations/llama-index.mdx
+++ b/integrations/llama-index.mdx
@@ -19,7 +19,7 @@ Before diving in, ensure that the following prerequisites are met:
 
 ## Step 1: Set Up Your Data Directory
 
-Create a folder named `data` in the root of your app folder. Download the [state of the union](https://github.com/hwchase17/langchain/blob/master/docs/extras/modules/state_of_the_union.txt) file (or any files of your own choice) and place it in the `data` folder.
+Create a folder named `data` in the root of your app folder. Download the [state of the union](https://github.com/langchain-ai/langchain/blob/master/docs/docs/modules/state_of_the_union.txt) file (or any files of your own choice) and place it in the `data` folder.
 
 ## Step 2: Create the Python Script
 


### PR DESCRIPTION
I udpated a broken link to the `state_of_the_union.txt` file in the Llama Index integrations doc.