### PR TITLE
Fix broken link to LangChain doc for MRKL example

### DIFF
--- a/examples/mrkl.mdx
+++ b/examples/mrkl.mdx
@@ -2,7 +2,7 @@
 title: MRKL
 ---
 
-Example inspired from the [LangChain doc](https://python.langchain.com/docs/modules/agents/how_to/mrkl)
+Example inspired from the [LangChain doc](https://js.langchain.com/docs/modules/agents/how_to/custom_mrkl_agent)
 
 ## Prerequisites
 


### PR DESCRIPTION
LangChain moved a reference to their MRKL example, this PR adjusts our own doc to the new link.