### PR TITLE
Add note about required environment variable for password authentication.

### DIFF
--- a/authentication/password.mdx
+++ b/authentication/password.mdx
@@ -14,8 +14,12 @@ You can verify the credentials against any service that you'd like (your own DB,
 ## Example
 
 ```python
+import os
 from typing import Optional
 import chainlit as cl
+
+# "CHAINLIT_CUSTOM_AUTH" environment variable must be set to any value
+os.environ["CHAINLIT_AUTH_SECRET"] = "my_secret"
 
 @cl.password_auth_callback
 def auth_callback(username: str, password: str):

--- a/authentication/password.mdx
+++ b/authentication/password.mdx
@@ -18,7 +18,7 @@ import os
 from typing import Optional
 import chainlit as cl
 
-# "CHAINLIT_CUSTOM_AUTH" environment variable must be set to any value
+# "CHAINLIT_AUTH_SECRET" environment variable must be set to any value
 os.environ["CHAINLIT_AUTH_SECRET"] = "my_secret"
 
 @cl.password_auth_callback


### PR DESCRIPTION
- Adding a note about the required environment variable so that the example code works without modification.
- I don't know if this is already referred in other sections but I think adding note in this section helps those who want to try the password authentication run the example code quickly.