### PR TITLE
Warn against in-app setting of Slack environment variables

### DIFF
--- a/deploy/slack.mdx
+++ b/deploy/slack.mdx
@@ -115,6 +115,8 @@ Navigate to the Install App tab and click on Install to Workspace.
 
 ## Set the Environment Variables
 
+<Note>Set the environment variables outside of your application code.</Note>
+
 ### Bot Token
 
 Once the slack application is installed, you will see the Bot User OAuth Token. Set this as an environment variable in your Chainlit app.


### PR DESCRIPTION
The current documentation doesn't explicitly warn against setting `SLACK_BOT_TOKEN` and `SLACK_SIGNING_SECRET` environment variables within the application code. This can lead to unexpected behavior where the Slack integration fails to work properly.

When the Slack endpoints are being added in the server setup file (`chainlit/backend/chainlit/server.py`), the following code is executed:

```python
# -------------------------------------------------------------------------------
#                               SLACK HANDLER
# -------------------------------------------------------------------------------
if os.environ.get("SLACK_BOT_TOKEN") and os.environ.get("SLACK_SIGNING_SECRET"):
    from chainlit.slack.app import slack_app_handler
    @router.post("/slack/events")
    async def slack_endpoint(req: Request):
        return await slack_app_handler.handle(req)
```

   
At this point, the user's application script has not yet run. Consequently, if the environment variables are set within the user's code, they won't be available when this check is performed. This results in the Slack endpoints not being added to the server, causing the Slack integration to fail.

This PR updates the documentation to clearly state that SLACK_BOT_TOKEN and SLACK_SIGNING_SECRET must be set externally to the application code.