### PR TITLE
Fix typo in customisation avatars.mdx

### DIFF
--- a/customisation/avatars.mdx
+++ b/customisation/avatars.mdx
@@ -5,10 +5,10 @@ title: Avatars
 The default assistant avatar is the favicon of the application. See how to customize the favicon [here](/customisation/custom-logo-and-favicon).
 
 However, you can customize the avatar by placing an image file in the `/public/avatars` folder.
-The image file should be named after the author of the message. For example, if the author is `My Assistant`, the avatar should be named `my-assistant.png`.
+The image file should be named after the author of the message. For example, if the author is `My Assistant`, the avatar should be named `my_assistant.png`.
 
 ```
 public/
 └── avatars/
-    └── my-assistant.png
+    └── my_assistant.png
 ```


### PR DESCRIPTION
To customise avatars is needed to use `_` instead of `-` when naming the files otherwise they won't be find by server.

```python
    avatar_id = avatar_id.strip().lower().replace(" ", "_")

    avatar_path = os.path.join(APP_ROOT, "public", "avatars", f"{avatar_id}.*")
```

Example, if your application config `name` is `My Assistant` then the avatar should be `public/avatars/my_assistant.png`. 


Server: 
https://github.com/Chainlit/chainlit/blob/add72385a2b8013e60718b65e2e82eb385a51773/backend/chainlit/server.py#L914