### PR TITLE
Update import ChatOpenAI

### DIFF
--- a/integrations/langchain.mdx
+++ b/integrations/langchain.mdx
@@ -56,7 +56,7 @@ Let's go through a small example.
 <CodeGroup>
 
 ```python Async LCEL
-from langchain.chat_models import ChatOpenAI
+from langchain_openai import ChatOpenAI
 from langchain.prompts import ChatPromptTemplate
 from langchain.schema import StrOutputParser
 from langchain.schema.runnable import Runnable
@@ -97,7 +97,7 @@ async def on_message(message: cl.Message):
 ```
 
 ```python Sync LCEL
-from langchain.chat_models import ChatOpenAI
+from langchain_openai import ChatOpenAI
 from langchain.prompts import ChatPromptTemplate
 from langchain.schema import StrOutputParser
 from langchain.schema.runnable import Runnable


### PR DESCRIPTION
Upgrade deprecated `ChainOpenAI` class import strategy to newer one.