### PR TITLE
Fix typo in Avatars

### DIFF
--- a/customisation/avatars.mdx
+++ b/customisation/avatars.mdx
@@ -5,10 +5,10 @@ title: Avatars
 The default assistant avatar is the favicon of the application. See how to customize the favicon [here](/customisation/custom-logo-and-favicon).
 
 However, you can customize the avatar by placing an image file in the `/public/avatars` folder.
-The image file should be named after the author of the message. For example, if the author is `My Assistant`, the avatar should be named `my-assistant.png`.
+The image file should be named after the author of the message. For example, if the author is `My Assistant`, the avatar should be named `my_assistant.png`.
 
 ```
 public/
 └── avatars/
-    └── my-assistant.png
+    └── my_assistant.png
 ```


### PR DESCRIPTION
Current documentation says to use a hyper `-` if your author has spaces but [the source code](https://github.com/Chainlit/chainlit/blob/main/backend/chainlit/server.py#L918) looks for an underscore `_`