### PR TITLE
Bump required Python version for coming release.

### DIFF
--- a/get-started/installation.mdx
+++ b/get-started/installation.mdx
@@ -2,7 +2,7 @@
 title: Installation
 ---
 
-Chainlit requires `python>=3.8`.
+Chainlit requires `python>=3.9`.
 
 You can install Chainlit it via pip as follows:
 


### PR DESCRIPTION
Coming release will drop Python 3.8 support.