### PR TITLE
Update custom.mdx / Database Schema

### DIFF
--- a/data-persistence/custom.mdx
+++ b/data-persistence/custom.mdx
@@ -52,7 +52,6 @@ CREATE TABLE IF NOT EXISTS steps (
     "type" TEXT NOT NULL,
     "threadId" UUID NOT NULL,
     "parentId" UUID,
-    "disableFeedback" BOOLEAN NOT NULL,
     "streaming" BOOLEAN NOT NULL,
     "waitForAnswer" BOOLEAN,
     "isError" BOOLEAN,
@@ -66,7 +65,8 @@ CREATE TABLE IF NOT EXISTS steps (
     "generation" JSONB,
     "showInput" TEXT,
     "language" TEXT,
-    "indent" INT
+    "indent" INT,
+    FOREIGN KEY ("threadId") REFERENCES threads("id") ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS elements (
@@ -82,7 +82,8 @@ CREATE TABLE IF NOT EXISTS elements (
     "page" INT,
     "language" TEXT,
     "forId" UUID,
-    "mime" TEXT
+    "mime" TEXT,
+    FOREIGN KEY ("threadId") REFERENCES threads("id") ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS feedbacks (
@@ -90,7 +91,8 @@ CREATE TABLE IF NOT EXISTS feedbacks (
     "forId" UUID NOT NULL,
     "threadId" UUID NOT NULL,
     "value" INT NOT NULL,
-    "comment" TEXT
+    "comment" TEXT,
+    FOREIGN KEY ("threadId") REFERENCES threads("id") ON DELETE CASCADE
 );
 ```
 


### PR DESCRIPTION
I updated the DB schema. It's mainly the disableFeedback column, as it no longer seems to be used in version 1.3.0rc1, even though it is defined as NOT NULL. I also added suggestions for foreign key and delete cascade to ensure consistency when a thread is deleted.