### PR TITLE
Update the import of AzureStorageClient

### DIFF
--- a/data-layers/sqlalchemy.mdx
+++ b/data-layers/sqlalchemy.mdx
@@ -92,7 +92,7 @@ Import the custom data layer and storage client, and indicate which data layer t
 ```python
 import chainlit as cl
 from chainlit.data.sql_alchemy import SQLAlchemyDataLayer
-from chainlit.data.storage_clients import AzureStorageClient
+from chainlit.data.storage_clients.azure import AzureStorageClient
 
 storage_client = AzureStorageClient(account_url="<your_account_url>", container="<your_container>")
 


### PR DESCRIPTION
This pull request includes a small change to the `data-layers/sqlalchemy.mdx` file. The change updates the import path for the `AzureStorageClient` to reflect its new location within the `chainlit.data.storage_clients.azure` module.

* [`data-layers/sqlalchemy.mdx`](diffhunk://#diff-6ca2c53eb925aa62e64060816d77e9d46e6fdaba8de4f0384a0a3a7cde008192L95-R95): Updated the import path for `AzureStorageClient` to `chainlit.data.storage_clients.azure`.AzureStorageClient is now moved to chainlit.data.storage_clients.azure