### PR TITLE
S3StorageClient has been moved

### DIFF
--- a/data-layers/dynamodb.mdx
+++ b/data-layers/dynamodb.mdx
@@ -15,7 +15,7 @@ Import the custom data layer and storage client, and set the `cl_data._data_laye
 ```python
 import chainlit.data as cl_data
 from chainlit.data.dynamodb import DynamoDBDataLayer
-from chainlit.data.storage_clients import S3StorageClient
+from chainlit.data.storage_clients.s3 import S3StorageClient
 
 storage_client = S3StorageClient(bucket="<Your Bucket>")
 


### PR DESCRIPTION
This pull request includes a small change to the `data-layers/dynamodb.mdx` file. The change involves importing the `S3StorageClient` from a different module path to ensure proper functionality.

* [`data-layers/dynamodb.mdx`](diffhunk://#diff-9286eb34b0020c9c01ea6524b686aabdbd0447b45ecb8567d758531e87a131bbL18-R18): Changed the import path of `S3StorageClient` to `chainlit.data.storage_clients.s3` to correctly import the storage client.S3StorageClient  should now be imported from chainlit.data.storage_clients.s3 and not chainlit.data.storage_clients