### PR TITLE
Ask-for-action docs missing `await`

### DIFF
--- a/api-reference/elements/pdf.mdx
+++ b/api-reference/elements/pdf.mdx
@@ -49,7 +49,7 @@ async def main():
       cl.Pdf(name="pdf1", display="inline", path="./pdf1.pdf", page=1)
     ]
 
-    cl.Message(content="Look at this local pdf!", elements=elements).send()
+    await cl.Message(content="Look at this local pdf!", elements=elements).send()
 ```
 
 ### Side and Page


### PR DESCRIPTION
When I copied and pasted this code, I got this error because the async function is missing an `await`.