### PR TITLE
docs: update github oath app creation url

### DIFF
--- a/authentication/oauth.mdx
+++ b/authentication/oauth.mdx
@@ -22,7 +22,7 @@ Follow these guides to create an OAuth app for your chosen provider(s). Then cop
 
 ### GitHub
 
-Go to this page to [create a new GitHub OAuth app](https://github.com/settings/apps).
+Go to this page to [create a new GitHub OAuth app](https://github.com/settings/applications/new).
 
 The callback URL should be: `CHAINLIT_URL/auth/oauth/github/callback`. If your Chainlit app is hosted at localhost:8000, you should use `http://localhost:8000/auth/oauth/github/callback`.
 


### PR DESCRIPTION
chore: update exact url directiing to github oauth app rather than github apps