### PR TITLE
update: Update sendUserMessage API

### DIFF
--- a/api-reference/elements/custom.mdx
+++ b/api-reference/elements/custom.mdx
@@ -103,7 +103,7 @@ interface APIs {
     // Call an action defined in the Chainlit app
     callAction: (action: {name: string, payload: Record<string, unknown>}) =>Promise<{success: boolean}>;
     // Send a user message
-    sendUserMessage: (message: string) => void;
+    sendUserMessage: (message: string, command?: string) => void;
 }
 ```
 


### PR DESCRIPTION
Simple update to the custom element's page to indicate a command value can be optionally sent with the `sendUserMessage` func. Related to Chainlit/chainlit#2459