### PR TITLE
docs: add modes to basic concepts

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -70,7 +70,8 @@
               "concepts/user-session",
               "concepts/element",
               "concepts/action",
-              "concepts/command"
+              "concepts/command",
+              "concepts/modes"
             ]
           },
           {


### PR DESCRIPTION
The "Modes" section is not displayed on the documentation website.

This happens because `concepts/modes` is missing from `docs.json`.
Adding this entry makes the section appear correctly in the rendered docs.
